### PR TITLE
restore -profile option

### DIFF
--- a/cmd/pbr/main.go
+++ b/cmd/pbr/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"runtime/pprof"
 
 	"github.com/hunterloftis/pbr/pkg/camera"
 	"github.com/hunterloftis/pbr/pkg/env"
@@ -30,7 +31,29 @@ func main() {
 	}
 }
 
+func createProfile() (*os.File, error) {
+       f, err := os.Create("profile.pprof")
+       if err != nil {
+               return nil, err
+       }
+       pprof.StartCPUProfile(f)
+       return f, nil
+}
+
+func stopProfile(f *os.File) {
+       pprof.StopCPUProfile()
+       f.Close()
+}
+
 func run(o *Options) error {
+	if o.Profile {
+		f, err := createProfile()
+		if err != nil {
+			return err
+		}
+		defer stopProfile(f)
+	}
+
 	mesh, err := obj.ReadFile(o.Scene, true)
 	if err != nil {
 		return err


### PR DESCRIPTION
The Profile option is still in the code but got dropped during the pbr2 refactor
(along with a few other options, it looks).

This simply restores the code and chucks it on top of main.run, since it's
nice to get a full view of the program.

Didn't see any other file or pkg worth putting the stubs into, but if you want it elsewhere I can fix.

thanks!